### PR TITLE
docker-compose to start TIG stack

### DIFF
--- a/datasource.yaml
+++ b/datasource.yaml
@@ -1,17 +1,17 @@
+---
 apiVersion: 1
 datasources:
   - name: influxdb
     type: influxdb
     access: proxy
     orgId: 1
-    url: http://172.17.0.1:8086
+    url: http://influxdb:8086
     password: juniper
     user: juniper
     database: juniper
     basicAuth: false
-    basicAuthUser: 
-    basicAuthPassword: 
-    withCredentials: 
+    basicAuthUser:
+    basicAuthPassword:
+    withCredentials:
     isDefault: true
     editable: true
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,43 @@
+---
+version: '2'
+
+networks:
+  tig:
+
+services:
+  influxdb:
+    image: influxdb:1.7.2
+    container_name: influxdb
+    expose:
+      - 8086
+      - 8083
+    volumes:
+      - $PWD/meta.db:/var/lib/influxdb/meta/meta.db
+    networks:
+      - tig
+
+  telegraf:
+    image: telegraf:1.9.1
+    container_name: telegraf
+    volumes:
+      - $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+    environment:
+      INFLUXDB_URL: http://influxdb:8086
+    depends_on:
+      - "influxdb"
+    networks:
+      - tig
+
+  grafana:
+    image: grafana/grafana:5.4.2
+    container_name: grafana
+    ports:
+      - "9081:3000"
+    volumes:
+      - $PWD/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml:ro
+      - $PWD/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:ro
+      - $PWD/dashboards:/var/tmp/dashboards
+    depends_on:
+      - "telegraf"
+    networks:
+      - tig

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -9,7 +9,7 @@
   str_as_tags = false
 
 [[outputs.influxdb]]
-      urls = ["http://172.17.0.1:8086"]
+      urls = ["http://influxdb:8086"]
       database = "juniper"
       timeout = "5s"
       username = "juniper"


### PR DESCRIPTION
Create a `docker-compose.yaml` to start TIG stack with provisioning

In the meantime, replace static `influxdb` IP address by hostname resolved by other container:

- Fix `bad gateway address` in data-source
- Fix error message to connect to `influxdb` service 